### PR TITLE
Support error handler chaining.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,5 @@
 #     https://www.atlassian.com/git/tutorials/saving-changes/gitignore
 # Learn more about Git LFS for large files:
 #     https://www.atlassian.com/git/tutorials/git-lfs
+/.idea
 .DS_Store

--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -33,7 +33,7 @@
 	<rule ref="PSR2.Methods.FunctionClosingBrace"/>
 
 	<!-- Check code for cross-version PHP compatibility. -->
-	<config name="testVersion" value="5.4-"/>
+	<config name="testVersion" value="7.0-"/>
 	<rule ref="PHPCompatibility">
 		<!-- Exclude PHP constants back-filled by PHPCS. -->
 		<exclude name="PHPCompatibility.Constants.NewConstants.t_finallyFound"/>

--- a/src/integrations/wp/tokens/wp-tokens.php
+++ b/src/integrations/wp/tokens/wp-tokens.php
@@ -17,21 +17,60 @@ class Wp_Tokens {
 	public static $integration = 'WP';
 
 	/**
+	 * Previous error handler.
+	 *
+	 * @var callable|null
+	 */
+	private $previous_error_handler;
+
+	/**
 	 * Wp_Tokens constructor.
 	 */
 	public function __construct() {
 		// Hide error for Automator Pro until Pro 3.1 is released.
 		if ( PHP_MAJOR_VERSION >= 7 ) {
-			set_error_handler(
-				function ( $errno, $errstr, $file ) {
-					return strpos( $file, '/tokens/wp-anon-tokens.php' ) !== false &&
-						   strpos( $errstr, 'Declaration of' ) === 0;
-				},
-				E_WARNING
-			);
+			// To support error handler chaining, we need to set our error handler with E_ALL error_levels.
+			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_set_error_handler
+			$this->previous_error_handler = set_error_handler( array( $this, 'error_handler' ) );
 		}
 
 		add_filter( 'automator_maybe_parse_token', array( $this, 'parse_wproles_token' ), 20, 6 );
+	}
+
+	/**
+	 * Error handler.
+	 *
+	 * @param int    $level   Error level.
+	 * @param string $message Error message.
+	 * @param string $file    File produced an error.
+	 * @param int    $line    Line number.
+	 *
+	 * @return bool
+	 * @noinspection PhpTernaryExpressionCanBeReplacedWithConditionInspection
+	 */
+	public function error_handler( int $level, string $message, string $file, int $line ): bool { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
+		$ua_error =
+			$level & E_WARNING &&
+			strpos( $file, '/tokens/wp-anon-tokens.php' ) !== false &&
+			strpos( $message, 'Declaration of' ) === 0;
+
+		// phpcs:ignore PHPCompatibility.FunctionUse.ArgumentFunctionsReportCurrentValue.NeedsInspection
+		return $ua_error ? true : $this->fallback_error_handler( func_get_args() );
+	}
+
+	/**
+	 * Fallback error handler.
+	 *
+	 * @param array $args Arguments.
+	 *
+	 * @return bool
+	 * @noinspection PhpTernaryExpressionCanBeReplacedWithConditionInspection
+	 */
+	private function fallback_error_handler( array $args ): bool {
+		return null === $this->previous_error_handler ?
+			// Use standard error handler.
+			false :
+			(bool) call_user_func_array( $this->previous_error_handler, $args );
 	}
 
 	/**


### PR DESCRIPTION
## Description

This PR correctly supports the PHP error handler chain.

When the previous error handler is set, the UA error handler should call it accordingly to make the chain work. In my plugin [KAGG Compatibility](https://github.com/kagg-design/kagg-compatibility), the PHP error handler is set in the mu-plugin created at the plugin activation. When UA is loaded, the previous handler already exists.

I implemented a similar error handler in the WPForms Development plugin and, partially, in the [WPForms](https://wordpress.org/plugins/wpforms-lite/) plugin. In the presence of UA, I am setting my error handler again on the `plugins_loaded` hook and making the UA error handler work as a fallback.

An error handler in the mu-plugin aimed to suppress annoying deprecated errors by PHP 8.0+ in different plugins or libraries. Letting the previous handler do its work would be good.

## Testing steps

1. Use PHP 8.4.
2. Activate UA from develop.
3. Install and activate Elementor.
4. See a bunch of deprecated errors in the debug.log.
5. Install and activate the KAGG Compatibility plugin (can be found on [wp.org](https://wordpress.org/plugins/kagg-compatibility/)).
6. Check that `kagg-compatibility-error-handler.php` is added to the `mu-plugins` folder.
7. See that Elementor errors are gone from the debug.log. This is due to the second error handler added after UA loading.
8. In the `kagg-compatibility-error-handler.php` comment out the line `add_action( 'plugins_loaded', [ $this, 'plugins_loaded' ], 500 )`.
9. See that Elementor deprecated errors create significant noise in the debug.log again.
10. Switch to the current branch.
11. See that Elementor deprecated errors are gone.