### PR TITLE
Event manager: Trigger - Fix namespace for the Em_Tokens class

### DIFF
--- a/src/integrations/events-manager/triggers/em-register.php
+++ b/src/integrations/events-manager/triggers/em-register.php
@@ -4,6 +4,7 @@ namespace Uncanny_Automator\Integrations\Events_Manager;
 
 use EM_Booking;
 use EM_Event;
+use Uncanny_Automator\Em_Tokens;
 
 /**
  * Class ANON_EM_REGISTER


### PR DESCRIPTION
Hi!

I noticed a small issue with the Event Manager integration

In the [em-register.php](https://github.com/UncannyOwl/Uncanny-Automator/blob/a937787c38f0f2067bcb3518f59fc9848cf51d99/src/integrations/events-manager/triggers/em-register.php) file, it expects the the `Em_Tokens` class (used [here](https://github.com/UncannyOwl/Uncanny-Automator/blob/a937787c38f0f2067bcb3518f59fc9848cf51d99/src/integrations/events-manager/triggers/em-register.php#L121)) to be inside the current namespace (so it will look for `Uncanny_Automator\Integrations\Events_Manager\Em_Tokens`)

However, this class namespace is Uncanny_Automator ([here](https://github.com/UncannyOwl/Uncanny-Automator/blob/a937787c38f0f2067bcb3518f59fc9848cf51d99/src/integrations/events-manager/tokens/em-tokens.php#L3)), so it should look for `Uncanny_Automator\Em_Tokens`)